### PR TITLE
Add eslint plugin for test names

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,8 @@ module.exports = {
     "destructuring",
     "jsx-max-len",
     "prettier",
-    "react"
+    "react",
+    "test-names"
   ],
   extends: ["airbnb"],
   rules: {
@@ -12,6 +13,7 @@ module.exports = {
 
     "destructuring/in-methods-params": "error",
     "compat/compat": "error",
+    "test-names/blacklist-word-in-test-name": [2, "should"],
 
     // Ternary
     "no-nested-ternary": "error",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "eslint-plugin-import": "^1.13.0",
     "eslint-plugin-jsx-max-len": "^1.0.0",
     "eslint-plugin-prettier": "^2.0.1",
+    "eslint-plugin-test-names": "^1.0.1",
     "prettier": "^1.2.0"
   },
   "authors": [


### PR DESCRIPTION
That way we can find tests with the word should in it, e.g.

it("should run fast") needs to become it("runs fast")